### PR TITLE
Remove obsolete Class() constructor.

### DIFF
--- a/java6/java/lang/Class.jml
+++ b/java6/java/lang/Class.jml
@@ -28,8 +28,6 @@ import java.io.InputStream;
 public final class Class<T> implements java.io.Serializable,
     AnnotatedElement, GenericDeclaration, Type {
 
-    private Class();
-
     /*@ also public normal_behavior
       @   ensures \result != null && !\result.equals("")
       @        && (* \result is the name of this class object *);


### PR DESCRIPTION
In recent java versions, the Class() constructor takes an argument and the default one has been removed.
This spec makes OpenJML fail.

Fixes https://github.com/OpenJML/OpenJML/issues/440
