### PR TITLE
Add some missing specs and exceptional behavior in java.nio.ByteBuffer

### DIFF
--- a/specs/java/nio/ByteBuffer.jml
+++ b/specs/java/nio/ByteBuffer.jml
@@ -33,6 +33,10 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures \result.capacity == n;
     //@   ensures \result.hb != null;
     //@   ensures \result.hb.length == n;
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires n < 0;
+    //@   signals_only IllegalArgumentException;
     //@ pure
     public static ByteBuffer allocateDirect(int n);
     
@@ -48,6 +52,10 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures \fresh(\result.hb);
     //@   ensures \result.hb.length == n;
     //@   ensures \result._isDirect == false;
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires n < 0;
+    //@   signals_only IllegalArgumentException;
     //@ pure
     public static ByteBuffer allocate(int n);
 
@@ -61,6 +69,10 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures \result.capacity == b.length;
     //@   ensures \result.hb == b;
     //@   ensures \result._isDirect == false;
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires offset < 0 || length < 0 || length > b.length - offset;
+    //@   signals_only IndexOutOfBoundsException;
     //@ pure
     public static ByteBuffer wrap(byte[] b, int offset, int length);
     
@@ -102,22 +114,56 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   assignable this.position;
     //@   ensures this.position == \old(this.position) + 1;
     //@   ensures \result == hb[\old(this.position)];
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires this.position >= this.limit;
+    //@   assignable \nothing;
+    //@   signals_only BufferUnderflowException;
     public abstract byte get();
 
     //@ public normal_behavior
+    //@   requires this.position < this.limit;
+    //@   requires !this.isReadOnly;
     //@   assignable this.position, hb[this.position];
     //@   ensures this.position == \old(this.position) + 1;
     //@   ensures hb[offset+\old(this.position)] == b;
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@      requires isReadOnly;
+    //@      signals_only ReadOnlyBufferException;
+    //@      also
+    //@      requires this.position >= this.limit;
+    //@      signals_only BufferOverflowException;
+    //@   |}
     public abstract ByteBuffer put(byte b);
 
     //@ public normal_behavior
+    //@   requires i >= 0 && i < this.limit;
     //@   ensures \result == hb[offset+i];
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires i < 0 || i >= this.limit;
+    //@   signals_only IndexOutOfBoundsException;
     //@ pure
     public abstract byte get(int i);
     
     //@ public normal_behavior
+    //@   requires i >= 0 && i < this.limit;
+    //@   requires !this.isReadOnly;
     //@   assignable hb[offset+i];
     //@   ensures hb[offset+i] == b;
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@       also
+    //@       requires i < 0 || i >= this.limit;
+    //@       signals_only IndexOutOfBoundsException;
+    //@   |}
     public abstract ByteBuffer put(int i, byte b);
     
     //@ public normal_behavior
@@ -129,6 +175,16 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures (\forall int i; 0 <= i && i < length; buf[offset + i] == this.hb[\old(this.position) + i]);
     //@   ensures (\forall int i; 0 <= i && i < offset; buf[i] == \old(buf[i]));
     //@   ensures (\forall int i; offset + length <= i && i < buf.length; buf[i] == \old(buf[i]));
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires length < 0 || offset < 0 || offset > limit - length;
+    //@       signals_only IndexOutOfBoundsException;
+    //@       also
+    //@       requires position > limit - length;
+    //@       signals_only BufferUnderflowException;
+    //@   |}
     public ByteBuffer get(byte[] buf, int offset, int length);
     
     //@ public normal_behavior
@@ -137,37 +193,77 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures \fresh(\result);
     //@   ensures this.position == \old(this.position) + buf.length;
     //@   ensures (\forall int i; 0 <= i && i < buf.length; buf[i] == this.hb[\old(this.position) + i]) ;
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires position > limit - buf.length;
+    //@   assignable \nothing;
+    //@   signals_only BufferUnderflowException;
     public ByteBuffer get(byte[] buf);
     
     //@ public normal_behavior
     //@   old int move = bbuf.limit - bbuf.position;
+    //@   requires !this.isReadOnly;
+    //@   requires bbuf != this;
     //@   requires move <= this.limit - this.position;
     //@   assignable hb[this.position .. this.position + (move - 1)], this.position, bbuf.position;
     //@   ensures position == \old(position) + move;
     //@   ensures bbuf.position == bbuf.limit;
     //@   ensures (\forall int i; \old(this.position) <= i && i < \old(this.position) + move; this.hb[i] == bbuf.hb[\old(bbuf.position) + (i-\old(this.position))]) ;
     //@ also public exceptional_behavior
-    //@   requires bbuf.limit - bbuf.position > this.limit - this.position;
     //@   assignable \nothing;
-    //@   signals_only BufferOverflowException ;
+    //@   {|
+    //@       requires bbuf.limit - bbuf.position > this.limit - this.position;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@       also
+    //@       requires bbuf == this;
+    //@       signals_only IllegalArgumentException;
+    //@   |}
     public ByteBuffer put(ByteBuffer bbuf);
 
     //@ public normal_behavior
     //@   requires offset >= 0 && length >= 0;
     //@   requires offset <= buf.length;
+    //@   requires !this.isReadOnly;
     //@   requires length <= buf.length - offset;
     //@   assignable this.hb[position..(position+(length-1))], this.position;
     //@   ensures position == Math.min(limit, \old(position) + length);
     //@   ensures (\forall int i; offset<=i && i<offset+length; buf[i] == hb[i-offset+\old(position)]); // FIXME - check that this forall will reason correctly
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@       also
+    //@       requires length > buf.length - offset;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires offset < 0 || length < 0 || offset > buf.length;
+    //@       signals_only IndexOutOfBoundsException;
+    //@   |}
     public ByteBuffer put(byte[] buf, int offset, int length);
 
     //@ public normal_behavior
     //@   requires position <= limit - buf.length;
+    //@   requires !this.isReadOnly;
     //@   old int moved = Math.min(buf.length, limit - position);
     //@   assignable this.position, this.hb[position .. (position + (moved -1))];
     //@   ensures \fresh(\result);
     //@   ensures this.position == \old(this.position) + moved;
     //@   ensures (\forall int i; 0<=i && i<moved; buf[i] == hb[i+\old(position)]); // FIXME - check that this forall will reason correctly
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@       also
+    //@       requires position > limit - buf.length;
+    //@       signals_only BufferOverflowException;
+    //@   |}
     public final ByteBuffer put(byte[] buf);
 
     //@ also public normal_behavior
@@ -176,12 +272,31 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     public final boolean hasArray();
     
     //@ also public normal_behavior
+    //@   requires hasArray();
     //@   ensures \result == hb;
+    //@ also
+    //@ public exceptional_behavior
+    //@   {|
+    //@       requires hb == null;
+    //@       signals_only UnsupportedOperationException;
+    //@       also
+    //@       requires this.isReadOnly && hb != null;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     //@ pure
     public final byte[] array();
     //@ also public normal_behavior
     //@     requires hb != null && !isReadOnly;
     //@     ensures \result == offset;
+    //@ also
+    //@ public exceptional_behavior
+    //@   {|
+    //@       requires hb == null;
+    //@       signals_only UnsupportedOperationException;
+    //@       also
+    //@       requires this.isReadOnly && hb != null;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     //@ pure
     public final int arrayOffset();
     public abstract ByteBuffer compact();
@@ -218,27 +333,58 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   assignable this.position;
     //@   ensures this.position == \old(this.position) + Short.BYTES;
     //@   ensures \result == asShort(hb[\old(position)],hb[\old(position+1)]);
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires position > limit - Short.BYTES;
+    //@   assignable \nothing;
+    //@   signals_only BufferOverflowException;
     public abstract short getShort();
 
     //@ public normal_behavior
     //@   requires position <= limit - Short.BYTES;
+    //@   requires !this.isReadOnly;
     //@   old int oldpos = this.position;
     //@   assignable this.position, hb[position .. (position + (Short.BYTES-1))];
     //@   ensures this.position == oldpos + Short.BYTES;
     //@   ensures getShort(oldpos) == s;
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires position > limit - Short.BYTES;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     public abstract ByteBuffer putShort(short s);
 
     //@ public normal_behavior
-    //@   requires i <= limit - Short.BYTES;
+    //@   requires 0 <= i && i <= limit - Short.BYTES;
     //@   ensures \result == asShort(hb[i],hb[i+1]);
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires i < 0 || i > limit - Short.BYTES;
+    //@   signals_only BufferOverflowException;
     //@ pure
     public abstract short getShort(int i);
 
     //@ public normal_behavior
     //@   requires position <= limit - Short.BYTES;
+    //@   requires !this.isReadOnly;
     //@   assignable this.position, hb[position .. (position + (Short.BYTES-1))];
     //@   ensures this.position == \old(this.position) + Short.BYTES;
     //@   ensures (* FIXME: result is bytes representation of the ints *);
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires i < 0 || i > limit - Short.BYTES;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     public abstract ByteBuffer putShort(int i, short s);
     
     public abstract ShortBuffer asShortBuffer();
@@ -248,6 +394,11 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   assignable this.position;
     //@   ensures this.position == \old(this.position) + Integer.BYTES;
     //@   ensures \result == asInt(hb[\old(position)],hb[\old(position+1)],hb[\old(position+2)],hb[\old(position+3)]);
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires position > limit - Integer.BYTES;
+    //@   assignable \nothing;
+    //@   signals_only BufferOverflowException;
     public abstract int getInt();
 
     //@ public normal_behavior
@@ -265,21 +416,47 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
 
     //@ public normal_behavior
     //@   requires position <= limit - Integer.BYTES;
+    //@   requires !this.isReadOnly;
     //@   assignable this.position, hb[position .. (position + (Integer.BYTES-1))];
     //@   ensures this.position == \old(this.position) + Integer.BYTES;
     //@   ensures getInt(\old(position)) == i;
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires position > limit - Integer.BYTES;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     public abstract ByteBuffer putInt(int i);
     
     //@ public normal_behavior
-    //@   requires i <= limit - Integer.BYTES;
+    //@   requires 0 <= i && i <= limit - Integer.BYTES;
     //@   ensures \result == asInt(hb[i],hb[i+1],hb[i+2],hb[i+3]);
+    //@ also
+    //@ public exceptional_behavior
+    //@   requires i < 0 || i > limit - Integer.BYTES;
+    //@   signals_only BufferOverflowException;
     //@ pure
     public abstract int getInt(int i);
 
     //@ public normal_behavior
-    //@   requires index <= limit - Integer.BYTES;
+    //@   requires 0 <= index && index <= limit - Integer.BYTES;
+    //@   requires !this.isReadOnly;
     //@   assignable hb[index .. (index + (Integer.BYTES-1))];
     //@   ensures getInt(index) == value;
+    //@ also
+    //@ public exceptional_behavior
+    //@   assignable \nothing;
+    //@   {|
+    //@       requires index < 0 || index > limit - Integer.BYTES;
+    //@       signals_only BufferOverflowException;
+    //@       also
+    //@       requires this.isReadOnly;
+    //@       signals_only ReadOnlyBufferException;
+    //@   |}
     public abstract ByteBuffer putInt(int index, int value);
     
     public abstract IntBuffer asIntBuffer();

--- a/specs/java/nio/ByteBuffer.jml
+++ b/specs/java/nio/ByteBuffer.jml
@@ -120,8 +120,16 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures hb[offset+i] == b;
     public abstract ByteBuffer put(int i, byte b);
     
-    
-    public ByteBuffer get(byte[] buf, int i, int j);
+    //@ public normal_behavior
+    //@   requires length >= 0 && offset >= 0;
+    //@   requires offset <= buf.length - length;
+    //@   requires this.position <= this.limit - length;
+    //@   assignable buf[*], this.position;
+    //@   ensures this.position == \old(this.position) + length;
+    //@   ensures (\forall int i; 0 <= i && i < length; buf[offset + i] == this.hb[\old(this.position) + i]);
+    //@   ensures (\forall int i; 0 <= i && i < offset; buf[i] == \old(buf[i]));
+    //@   ensures (\forall int i; offset + length <= i && i < buf.length; buf[i] == \old(buf[i]));
+    public ByteBuffer get(byte[] buf, int offset, int length);
     
     //@ public normal_behavior
     //@   requires position <= limit - buf.length;

--- a/specs/java/nio/ByteBuffer.jml
+++ b/specs/java/nio/ByteBuffer.jml
@@ -108,6 +108,16 @@ public abstract class ByteBuffer extends Buffer implements Comparable<ByteBuffer
     //@   ensures \result.isReadOnly == isReadOnly;
     //@ pure
     public abstract ByteBuffer duplicate();
+    //@ public normal_behavior
+    //@   ensures \fresh(\result);
+    //@   ensures \result.offset == offset;
+    //@   ensures \result.mark == mark;
+    //@   ensures \result.position == position;
+    //@   ensures \result.limit == limit;
+    //@   ensures \result.capacity == capacity;
+    //@   ensures \result.hb == hb;
+    //@   ensures \result.isReadOnly;
+    //@ pure
     public abstract ByteBuffer asReadOnlyBuffer();
     
     //@ public normal_behavior


### PR DESCRIPTION
Based on other specs for java.nio.ByteBuffer, this adds a simple spec for the normal behavior of ByteBuffer::get(byte[] buf, int offset, int length) and for asReadOnlyBuffer(). Also adds exceptional behavior specs to most methods, where the javadoc specifies exceptions.