### PR TITLE
Add exceptional behavior specs to Arrays.copyOf() and copyOfRange() methods

### DIFF
--- a/specs/java/util/Arrays.jml
+++ b/specs/java/util/Arrays.jml
@@ -2034,6 +2034,7 @@ public class Arrays {
     public static char[] copyOf(/*@ nullable @*/ char[] src, int newLength);
 
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires newLength >= 0;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == newLength;
@@ -2047,6 +2048,7 @@ public class Arrays {
     public static short[] copyOf(/*@ nullable @*/ short[] src, int newLength);
 
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires newLength >= 0;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == newLength;
@@ -2060,6 +2062,7 @@ public class Arrays {
     public static int[] copyOf(/*@ nullable @*/ int[] src, int newLength);
 
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires newLength >= 0;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == newLength;
@@ -2072,8 +2075,64 @@ public class Arrays {
     //@ pure
     public static long[] copyOf(/*@ nullable @*/ long[] src, int newLength);
 
-    // FIXME - all the other copyOf calls
+    //@ public normal_behavior
+    //@   requires src != null;
+    //@   requires newLength >= 0;
+    //@   ensures \fresh(\result);
+    //@   ensures \result.length == newLength;
+    //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
+    //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
+    //@ pure
+    public static float[] copyOf(/*@ nullable @*/ float[] src, int newLength);
+    
+    //@ public normal_behavior
+    //@   requires src != null;
+    //@   requires newLength >= 0;
+    //@   ensures \fresh(\result);
+    //@   ensures \result.length == newLength;
+    //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
+    //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
+    //@ pure
+    public static double[] copyOf(/*@ nullable @*/ double[] src, int newLength);
+    
+    //@ public normal_behavior
+    //@   requires src != null;
+    //@   requires newLength >= 0;
+    //@   ensures \fresh(\result);
+    //@   ensures \result.length == newLength;
+    //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
+    //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == null);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
+    //@ pure
+    public static <T> T[] copyOf(/*@ nullable @*/ T[] src, int newLength);
 
+    //@ public normal_behavior
+    //@   requires src != null;
+    //@   requires newLength >= 0;
+    //@   ensures \fresh(\result);
+    //@   ensures \result.length == newLength;
+    //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
+    //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == null);
+    //@   ensures \elemtype(\typeof(\result)) == \type(T);
+    //@ // FIXME another exceptional case: if T and U are not compatible types. Not clear how to specify it
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
+    //@ pure
+    public static <T,U> T[] copyOf(/*@ nullable @*/ U[] src, int newLength, Class<? extends T[]> newType);
+    
 //    public static <T> java.util.Spliterator<T> spliterator(T[]);
 //    public static <T> java.util.Spliterator<T> spliterator(T[], int, int);
 //    public static java.util.Spliterator$OfInt spliterator(int[]);

--- a/specs/java/util/Arrays.jml
+++ b/specs/java/util/Arrays.jml
@@ -1790,7 +1790,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1811,7 +1811,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == false);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1832,7 +1832,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1853,7 +1853,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1874,7 +1874,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1895,7 +1895,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1916,7 +1916,7 @@ public class Arrays {
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1938,7 +1938,7 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < src.length - from; \result[i] == src[i+from]);
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == 0);
     //@   |}
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1960,7 +1960,7 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < src.length - from; \result[i] == src[i+from]);
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == null);
     //@   |}
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1983,7 +1983,7 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == null);
     //@   |}
     //@ // FIXME another exceptional case: if T and U are not compatible types. Not clear how to specify it
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires from < 0 || from > src.length || from > to || src == null;
     //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
     //@   signals (NullPointerException) src == null;
@@ -1998,7 +1998,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2012,7 +2012,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == false);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2026,7 +2026,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2040,7 +2040,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2054,7 +2054,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2068,7 +2068,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2082,7 +2082,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2096,7 +2096,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2110,7 +2110,7 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == null);
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;
@@ -2126,7 +2126,7 @@ public class Arrays {
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == null);
     //@   ensures \elemtype(\typeof(\result)) == \type(T);
     //@ // FIXME another exceptional case: if T and U are not compatible types. Not clear how to specify it
-    //@ also public exceptional_behavior
+    //@ also private exceptional_behavior
     //@   requires src == null || newLength < 0;
     //@   signals (NullPointerException) src == null;
     //@   signals (NegativeArraySizeException) newLength < 0;

--- a/specs/java/util/Arrays.jml
+++ b/specs/java/util/Arrays.jml
@@ -1778,104 +1778,154 @@ public class Arrays {
      */
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static byte[] copyOfRange(byte[] src, int from, int to);
+    public static byte[] copyOfRange(/*@ nullable @*/ byte[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == false);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static boolean[] copyOfRange(boolean[] src, int from, int to);
+    public static boolean[] copyOfRange(/*@ nullable @*/ boolean[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static short[] copyOfRange(short[] src, int from, int to);
+    public static short[] copyOfRange(/*@ nullable @*/ short[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static int[] copyOfRange(int[] src, int from, int to);
+    public static int[] copyOfRange(/*@ nullable @*/ int[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static long[] copyOfRange(long[] src, int from, int to);
+    public static long[] copyOfRange(/*@ nullable @*/ long[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static float[] copyOfRange(float[] src, int from, int to);
+    public static float[] copyOfRange(/*@ nullable @*/ float[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to && to <= src.length;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < to; \result[i-from] == src[i]);
     //@ also public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= src.length && src.length < to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
     //@   ensures (\forall int i; from <= i && i < src.length; \result[i-from] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < to; \result[i-from] == 0);
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static double[] copyOfRange(double[] src, int from, int to);
+    public static double[] copyOfRange(/*@ nullable @*/ double[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
@@ -1888,10 +1938,16 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < src.length - from; \result[i] == src[i+from]);
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == 0);
     //@   |}
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static char[] copyOfRange(char[] src, int from, int to);
+    public static char[] copyOfRange(/*@ nullable @*/ char[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
@@ -1904,10 +1960,16 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < src.length - from; \result[i] == src[i+from]);
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == null);
     //@   |}
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static <T> T[] copyOfRange(T[] src, int from, int to);
+    public static <T> T[] copyOfRange(/*@ nullable @*/ T[] src, int from, int to);
     
     //@ public normal_behavior
+    //@   requires src != null;
     //@   requires 0 <= from && from <= to;
     //@   ensures \fresh(\result);
     //@   ensures \result.length == to - from;
@@ -1920,8 +1982,14 @@ public class Arrays {
     //@       ensures (\forall int i; 0 <= i && i < src.length - from; \result[i] == src[i+from]);
     //@       ensures (\forall int i; 0 <= i && i < to - src.length; \result[i+src.length-from] == null);
     //@   |}
+    //@ // FIXME another exceptional case: if T and U are not compatible types. Not clear how to specify it
+    //@ also public exceptional_behavior
+    //@   requires from < 0 || from > src.length || from > to || src == null;
+    //@   signals (ArrayIndexOutOfBoundsException) from < 0 || (src != null && from > src.length);
+    //@   signals (NullPointerException) src == null;
+    //@   signals (IllegalArgumentException) from > to;
     //@ pure
-    public static <T,U> T[] copyOfRange(U[] src, int from, int to, Class<? extends T[]> newType);
+    public static <T,U> T[] copyOfRange(/*@ nullable @*/ U[] src, int from, int to, Class<? extends T[]> newType);
     
     //@ public normal_behavior
     //@   requires src != null;
@@ -1930,8 +1998,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static byte[] copyOf(byte[] src, int newLength);
+    public static byte[] copyOf(/*@ nullable @*/ byte[] src, int newLength);
 
     //@ public normal_behavior
     //@   requires src != null;
@@ -1940,8 +2012,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == false);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static boolean[] copyOf(boolean[] src, int newLength);
+    public static boolean[] copyOf(/*@ nullable @*/ boolean[] src, int newLength);
 
     //@ public normal_behavior
     //@   requires src != null;
@@ -1950,8 +2026,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static char[] copyOf(char[] src, int newLength);
+    public static char[] copyOf(/*@ nullable @*/ char[] src, int newLength);
 
     //@ public normal_behavior
     //@   requires newLength >= 0;
@@ -1959,8 +2039,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static short[] copyOf(short[] src, int newLength);
+    public static short[] copyOf(/*@ nullable @*/ short[] src, int newLength);
 
     //@ public normal_behavior
     //@   requires newLength >= 0;
@@ -1968,8 +2052,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static int[] copyOf(int[] src, int newLength);
+    public static int[] copyOf(/*@ nullable @*/ int[] src, int newLength);
 
     //@ public normal_behavior
     //@   requires newLength >= 0;
@@ -1977,8 +2065,12 @@ public class Arrays {
     //@   ensures \result.length == newLength;
     //@   ensures (\forall int i; 0 <= i && i < src.length && i < newLength; \result[i] == src[i]);
     //@   ensures (\forall int i; src.length <= i && i < newLength; \result[i] == 0);
+    //@ also public exceptional_behavior
+    //@   requires src == null || newLength < 0;
+    //@   signals (NullPointerException) src == null;
+    //@   signals (NegativeArraySizeException) newLength < 0;
     //@ pure
-    public static long[] copyOf(long[] src, int newLength);
+    public static long[] copyOf(/*@ nullable @*/ long[] src, int newLength);
 
     // FIXME - all the other copyOf calls
 


### PR DESCRIPTION
Also fills in a few missing Arrays.copyOf() specs

There is one problem, though, which is that the type-converting ones (e.g., `<T, U> T[] copyOf(...)`) specify that an ArrayStoreException should be thrown if the types don't match, and I'm unsure how to specify that.